### PR TITLE
Fix bug in creating_transcript_models b/c  >0 values of distance option

### DIFF
--- a/R/add_data.R
+++ b/R/add_data.R
@@ -40,6 +40,6 @@ methods::setMethod("add_data",
           )
       # reorder the counts as the order in bins
       transcript_quantifier@counts <-
-          bw_counts[match(names(bw_counts), names(bins))]
+          bw_counts[names(transcript_quantifier@models)]
       return(transcript_quantifier)
 })

--- a/R/transcript_quantifier-class.R
+++ b/R/transcript_quantifier-class.R
@@ -150,7 +150,8 @@ transcript_quantifier <- function(transcripts, transcript_name_column,
                 bin_size = bin_size)
 
   # Create transcript models
-  tx_models <- create_transcript_models(tx_grps, grp_bins,
+  tx_models <- create_transcript_models(transcript_groups = tx_grps,
+                                        bins = grp_bins,
                                         transcript_name_column)
 
   # Create masks


### PR DESCRIPTION
Fixes bug created when there are bins that no transcripts overlap. Resulted in some bins being dropped during model creation step. Re-worked calculating overlaps to do it for all bins.