### PR TITLE
transcript grouping bugfix

### DIFF
--- a/R/group_transcripts.R
+++ b/R/group_transcripts.R
@@ -24,61 +24,36 @@ group_transcripts <- function(transcript_granges, distance = 0, threads = 1) {
   if (!methods::is(transcript_granges, "GRanges")) {
     stop("transcript is not a TxDb object")
   }
-  # Ensure everything is sorted
+  # Ensure everything is sorted, otherwise later assignment assumptions fail
   transcript_granges <- GenomeInfoDb::sortSeqlevels(transcript_granges)
   transcript_granges <- GenomicRanges::sort(transcript_granges)
   # Assign a unique id to each row
   transcript_granges$unique_id <- seq_len(length(transcript_granges))
-  # Get chromosome and strand strings
-  strand <- S4Vectors::decode(GenomicRanges::seqnames(transcript_granges))
-  chrom <- S4Vectors::decode(GenomicRanges::strand(transcript_granges))
-  # Create iterator over transcript_granges with chromosome_strand information
-  tx_gr_iter <- iterators::isplit(transcript_granges,
-                                  paste0(strand, "_", chrom))
+  # Create expanded granges
+  tx_granges_expand <- GenomicRanges::resize(transcript_granges,
+                             width = GenomicRanges::width(transcript_granges) +
+                               floor(distance / 2),
+                             fix = "end")
+  tx_granges_expand <- GenomicRanges::resize(tx_granges_expand,
+                             width = GenomicRanges::width(tx_granges_expand) +
+                               ceiling(distance / 2),
+                             fix = "start")
+  tx_granges_expand <- GenomicRanges::trim(tx_granges_expand)
+  # Reduce granges to get unions of overlapping ranges which will become the
+  # transcript groups. The -/+ 1 bit is to assure that perfectly adjoining
+  # groups are not merged
+  GenomicRanges::end(tx_granges_expand) <-
+    GenomicRanges::end(tx_granges_expand) - 1
+  tx_reduce <- GenomicRanges::reduce(tx_granges_expand)
+  GenomicRanges::end(tx_reduce) <- GenomicRanges::end(tx_reduce) + 1
+  # Get the group assignments
+  group_assignment <- GenomicRanges::findOverlaps(transcript_granges, tx_reduce)
+  # Create group vector string
+  uid <- paste0(subjectHits(group_assignment), "_",
+                GenomicRanges::strand(transcript_granges))
 
-  if (threads > 1) {
-    # Create parallel cluster and register it with the foreach backend
-    cluster <- snow::makeCluster(threads)
-    doSNOW::registerDoSNOW(cluster)
-    `%doloop%` <- foreach::`%dopar%`
-  } else {
-    `%doloop%` <- foreach::`%do%`
-  }
-  # Iterate over
-  tx_groups <- foreach::foreach(tx = tx_gr_iter, .combine = "rbind") %doloop% {
-    # Get distance between end of transcript and start of following trans.
-    # Negative values mean they overlap
-    dist_to_next <- with(tx, GenomicRanges::start(value)[-1] -
-                           GenomicRanges::end(value[1:(length(value) - 1)]))
-    # Compute where breaks should be
-    break_after <- which(dist_to_next > distance)
-    # Compute groupings
-    if (length(break_after) > 0) {
-      num_groups <- length(break_after) + 1
-      members_per_group <- c(diff(c(0, break_after)),
-                             length(tx$value) -
-                               break_after[length(break_after)])
-      group_labels <- paste0(tx$key, ":",
-                             rep(x = 1:num_groups, times = members_per_group))
-    } else {
-      group_labels <- rep(paste0(tx$key, ":", 1), length(tx$value))
-    }
-    uid_grouping <- data.frame(uid = tx$value$unique_id,
-                               group_labels = group_labels)
-    return(uid_grouping)
-  }
-  # Stop cluster
-  if (threads > 1) {
-    snow::stopCluster(cluster)
-  }
   # Split the transcripting into their groups
-  tx_groups <- tx_groups[order(tx_groups$uid), ]
   gr_groups <- GenomicRanges::split(transcript_granges,
-                                    f = tx_groups$group_labels)
+                                    f = uid)
   return(gr_groups)
-}
-
-## Appease R CMD check
-if (getRversion() >= "2.15.1") {
-  utils::globalVariables(c("tx"))
 }

--- a/tests/testthat/test-transcript_model.R
+++ b/tests/testthat/test-transcript_model.R
@@ -30,6 +30,14 @@ test_that("Transcripts group correctly (single strand)", {
   # Check that the correct number of groups are formed
   expect_equal(length(tx_grp_expand_1), 2)
   expect_equal(length(tx_grp_expand_2), 1)
+  # Additional test case for granges where there are three transcripts
+  # where two non-overlapping transcripts are nested within a third
+  gr_3 <- GenomicRanges::GRanges(1,
+                                 IRanges::IRanges(
+                                   c(1, 1, 500),
+                                   c(1000, 200, 700)
+                                 ))
+  expect_equal(length(group_transcripts(gr_3)), 1)
 })
 
 test_that("Transcripts group correctly (double strand)", {


### PR DESCRIPTION
Fixed bug where two sequential non-overlapping transcripts would not be merged, even if they both were embedded within a third transcript.