### PR TITLE
Hotfix filtering plotting

### DIFF
--- a/R/plot_tq.R
+++ b/R/plot_tq.R
@@ -110,7 +110,7 @@ plot_model <- function(transcript_quantifier,
     # Masks track
     masks_track <- Gviz::AnnotationTrack(target_masks,
                                          name = "masks",
-                                         feature = strand(target_masks),
+                                         feature = Gviz::strand(target_masks),
                                          shape = "box",
                                          chromosome = chrom)
     # Some objects for data retrieval

--- a/R/transcript_shape_profile-class.R
+++ b/R/transcript_shape_profile-class.R
@@ -155,6 +155,10 @@ transcript_shape_profile <- function(transcripts,
   ma_dt[, group := names(mod_agree)]
   ma_dt <- ma_dt[percent_transcribed >= min_percent_transcribed &
                    percent_match >= percent_model_match]
+  message("Groups remaining: ", length(unique(ma_dt$group)))
+  if (nrow(ma_dt) == 0) {
+    stop("No transcripts passed filters to be used for model fitting")
+  }
   message("Selecting best fitting transcript per group ...")
   final_tx <- ma_dt[, .SD[which.max(percent_match)], by = "group"]
 


### PR DESCRIPTION
Fix access to `strand()` in plotting. Also added error catch if transcript GOF statistic filtering removes all transcripts.