### PR TITLE
Fixed issue where data would get returned out of order

### DIFF
--- a/R/process_data.R
+++ b/R/process_data.R
@@ -63,7 +63,8 @@ methods::setMethod("summarize_bigwig", signature(bins = "GRangesList"),
   ))
 
   # Re-list the values
-  sum_list <- split(sum_flat, attr(sum_flat, "names"))
+  sum_list <- split(sum_flat, factor(attr(sum_flat, "names"),
+                                     levels = names(bins)))
   return(sum_list)
 })
 


### PR DESCRIPTION
Auto-leveling of names of list elements caused resorting