### PR TITLE
Change inactive transcript logic

### DIFF
--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -75,7 +75,8 @@ function.
 tq <- fit(tq)
 ```
 
-To view the results we can all the `abundance_table()` function.
+To view the results we can all the `transcript_abundance()` or `gene_abundance()`
+function.
 ```{r}
 transcript_abundance(tq)
 ```


### PR DESCRIPTION
Now in the case where multiple transcripts are assigned to a single model (due to identical models at the specified bin scale) this will be overridden if one or more transcripts assigned to the same model are active